### PR TITLE
Edge case fix for gdsfactory merge behavior for exactly one polygon

### DIFF
--- a/rect2gds.py
+++ b/rect2gds.py
@@ -343,10 +343,13 @@ def merge_polygons_by_layer(component):
         layer_index = gf.get_layer(layer)
         # save labels before clearing the layer.
         labels = component.get_labels(layer=layer, recursive=False)
-        region = gf.kdb.Region(
+        source_region = gf.kdb.Region(
             component.kdb_cell.begin_shapes_rec(layer_index)
         )
-        region.merge()
+        source_region.merge()
+        # independent copy before clearing layer
+        region = gf.kdb.Region()
+        region.insert(source_region)
         component.shapes(layer_index).clear()
         component.shapes(layer_index).insert(region)
         for label in labels:


### PR DESCRIPTION
I found an edge case when there is exactly only one polygon of a given material in a layout. When this is the case, after calling the merge function, the polygon gets dropped because of how the boolean function operates in merge as well as how the data of the object is stored. Curiously, this does not happen when multiple polygons are present and not merged. 

The only result of this bug was that the alignment layer was getting dropped. It escaped me because I thought it was behavior related to the jigsaw repo but while troubleshooting that I realized it was due to the python script.